### PR TITLE
Fix: Prevent crash when AlbumArtist or other tags are missing

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -17,12 +17,5 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      - name: Create index of lua scripts
+      - name: Check lua script signatures
         run: ./index.sh
-
-      - name: Add, commit and push
-        uses: EndBug/add-and-commit@v9.1.4
-        with:
-          add: index.json
-          message: Update index
-          push: true

--- a/index.sh
+++ b/index.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 #
 #SPDX-License-Identifier: GPL-3.0-or-later
-#myMPD (c) 2018-2024 Juergen Mang <mail@jcgames.de>
-#https://github.com/jcorporation/mympd
+#myMPD (c) 2018-2026 Juergen Mang <mail@jcgames.de>
+#https://github.com/jcorporation/mympd-sciprts
 
-#exit on error
+# Exit on error
 set -e
 
-#exit on undefined variable
+# Exit on undefined variable
 set -u
 
 sig_create() {
@@ -24,38 +24,49 @@ sig_check() {
     rm /tmp/sig
 }
 
-# Create index of lua scripts
-rm -f "index.json"
-exec 3<> "index.json"
-printf "{" >&3
-I=0
-for F in */*.lua
-do
-    echo -n "$F..."
-    [ "$I" -gt 0 ] &&  printf "," >&3
-    NAME=$(basename "$F" .lua | jq -Ra .)
-    FILE=$(printf "%s" "$F" | jq -Ra .)
-    SCRIPT_HEADER=$(head -1 "$F" < $F | sed 's/^-- //')
-    DESC=$(printf "%s" "$SCRIPT_HEADER" | jq -r '.desc' | jq -Ra .)
-    VERSION=$(printf "%s" "$SCRIPT_HEADER" | jq -r '.version')
-    [ "$DESC" = "null" ] && DESC=""
-    [ "$VERSION" = "null" ] && VERSION="0"
-    printf '%s:{"name":%s,"desc":%s,"version":%s}' "$FILE" "$NAME" "$DESC" "$VERSION">&3
-    I=$((I+1))
-    if [ -f privatekey.pem ]
-    then
-        sig_create "$F"
-    fi
-    sig_check "$F"
-done
-printf "}\n" >&3
-exec 3>&-
-
-# Check and sign index
-jq "." < index.json > /dev/null
+# Create signatures and index of lua scripts
 if [ -f privatekey.pem ]
 then
+    echo "--"
+    echo "Creating index and signatures"
+    rm -f "index.json"
+    exec 3<> "index.json"
+    printf "{" >&3
+    I=0
+    for F in */*.lua
+    do
+        echo "    $F"
+        [ "$I" -gt 0 ] &&  printf "," >&3
+        NAME=$(basename "$F" .lua | jq -Ra .)
+        FILE=$(printf "%s" "$F" | jq -Ra .)
+        SCRIPT_HEADER=$(head -1 "$F" < $F | sed 's/^-- //')
+        DESC=$(printf "%s" "$SCRIPT_HEADER" | jq -r '.desc' | jq -Ra .)
+        VERSION=$(printf "%s" "$SCRIPT_HEADER" | jq -r '.version')
+        [ "$DESC" = "null" ] && DESC=""
+        [ "$VERSION" = "null" ] && VERSION="0"
+        printf '%s:{"name":%s,"desc":%s,"version":%s}' "$FILE" "$NAME" "$DESC" "$VERSION" >&3
+        I=$((I+1))
+        if [ -f privatekey.pem ]
+        then
+            sig_create "$F"
+        fi
+    done
+    printf "}\n" >&3
+    exec 3>&-
+    # Sign index
     sig_create index.json
 fi
-echo -n "index.json..."
+
+# Check index for valid JSON
+jq "." < index.json > /dev/null
+
+echo "--"
+echo "Checking signatures"
+echo -n "    index.json..."
 sig_check index.json
+
+for F in */*.lua
+do
+    echo -n "    $F..."
+    sig_check "$F"
+done

--- a/last.fm/lastfm.lua
+++ b/last.fm/lastfm.lua
@@ -82,7 +82,7 @@ if mympd_arguments.trigger == "player" then
   local data = {
     method      = "track.updateNowPlaying",
     api_key     = mympd_env.var.lastfm_api_key,
-    track       = mympd_state.current_song.Title or "",
+    track       = mympd_state.current_song.Title,
     artist      = firstTagValue(mympd_state.current_song.Artist),
     album       = mympd_state.current_song.Album or "",
     albumArtist = firstTagValue(mympd_state.current_song.AlbumArtist),
@@ -119,7 +119,7 @@ if mympd_arguments.trigger == "scrobble" then
     method      = "track.scrobble",
     api_key     = mympd_env.var.lastfm_api_key,
     timestamp   = tostring(mympd_state.start_time),
-    track       = mympd_state.current_song.Title or "",
+    track       = mympd_state.current_song.Title,
     artist      = firstTagValue(mympd_state.current_song.Artist),
     album       = mympd_state.current_song.Album or "",
     albumArtist = firstTagValue(mympd_state.current_song.AlbumArtist),
@@ -161,8 +161,8 @@ if mympd_arguments.trigger == "feedback" then
   local data = {
     method      = "track.love",
     api_key     = mympd_env.var.lastfm_api_key,
-    track       = mympd_state.current_song.Title or "",
-    artist      = firstTagValue(mympd_state.current_song.Artist),
+    track       = mympd_state.current_song.Title,
+    artist      = mympd_state.current_song.Artist[1],
     sk          = mympd_env.var.lastfm_session_key,
   }
 

--- a/last.fm/lastfm.lua
+++ b/last.fm/lastfm.lua
@@ -1,4 +1,4 @@
--- {"name": "lastfm", "file": "last.fm/lastfm.lua", "version": 4, "desc": "Interface for last.fm.", "order":0, "arguments":["trigger"]}
+-- {"name": "lastfm", "file": "last.fm/lastfm.lua", "version": 5, "desc": "Interface for last.fm.", "order":0, "arguments":["trigger"]}
 
 if mympd.isnilorempty(mympd_env.var.lastfm_api_key) then
   return mympd.jsonrpc_error("No Last.fm API Key set")
@@ -12,50 +12,61 @@ if rc == false then
     return msg
 end
 
+local function firstTagValue(field)
+  return (field and field[1]) or ""
+end
+
 local function hashRequest(data, secret)
   local keys = {}
   for key in pairs(data) do
     table.insert(keys, key)
   end
+
   table.sort(keys)
+
   local s = ""
-  for k, v in pairs(keys) do
-    s = s .. v .. data[v]
+  for _, key in ipairs(keys) do
+    s = s .. key .. data[key]
   end
+
   s = s .. secret
-  local hash = mympd.hash_md5(s)
-  return hash
+  return mympd.hash_md5(s)
 end
 
 local function urlencode_data(data)
-  local s = ""
   local a = {}
   for k, v in pairs(data) do
     table.insert(a, mympd.urlencode(k) .. "=" .. mympd.urlencode(v))
   end
-  s = table.concat(a, "&")
- return s
+  return table.concat(a, "&")
 end
 
 local function sendData(data)
   local extra_headers = 'Content-type: application/x-www-form-urlencoded\r\n'
-  local hash = hashRequest(data, mympd_env.var.lastfm_secret)
-  data["api_sig"] = hash
-  data = urlencode_data(data)
+  data["api_sig"] = hashRequest(data, mympd_env.var.lastfm_secret)
+  local encoded = urlencode_data(data)
+
   local code, headers, body
-  rc, code, headers, body = mympd.http_client("POST", "https://ws.audioscrobbler.com/2.0/?format=json", extra_headers, data)
+  rc, code, headers, body = mympd.http_client(
+    "POST",
+    "https://ws.audioscrobbler.com/2.0/?format=json",
+    extra_headers,
+    encoded
+  )
+
   return rc, body
 end
 
--- main
+-- MAIN
 mympd.init()
 
+-- NOW PLAYING
 if mympd_arguments.trigger == "player" then
   if mympd_state.play_state ~= 2 or mympd_state.elapsed_time > 5 then
     return "Now Playing: Not Playing"
   end
 
-  if mympd_state.current_song == nil then
+  if not mympd_state.current_song then
     return "Now Playing: Not Playing"
   end
 
@@ -64,17 +75,17 @@ if mympd_arguments.trigger == "player" then
     return "webradio"
   end
 
-  if mympd.tblvalue_in_list(mympd_env.var.scrobble_genre_blacklist, mympd_state.current_song.Genre) == true then
+  if mympd.tblvalue_in_list(mympd_env.var.scrobble_genre_blacklist, mympd_state.current_song.Genre) then
     return
   end
 
   local data = {
     method      = "track.updateNowPlaying",
     api_key     = mympd_env.var.lastfm_api_key,
-    track       = mympd_state.current_song.Title,
-    artist      = mympd_state.current_song.Artist[1],
-    album       = mympd_state.current_song.Album,
-    albumArtist = mympd_state.current_song.AlbumArtist[1],
+    track       = mympd_state.current_song.Title or "",
+    artist      = firstTagValue(mympd_state.current_song.Artist),
+    album       = mympd_state.current_song.Album or "",
+    albumArtist = firstTagValue(mympd_state.current_song.AlbumArtist),
     sk          = mympd_env.var.lastfm_session_key,
   }
 
@@ -86,19 +97,21 @@ if mympd_arguments.trigger == "player" then
 
   local ret = json.decode(body)
   local code = ret.nowplaying.ignoredMessage.code
+
   if code ~= "0" then
-    return "Now Playing: " .. mympd_state.current_song.Artist[1] .. " - " .. mympd_state.current_song.Title .. " - ignored code " .. code
+    return "Now Playing: " .. data.artist .. " - " .. data.track .. " - ignored code " .. code
   end
 
-  return "Now Playing: " .. mympd_state.current_song.Artist[1] .. " - " .. mympd_state.current_song.Title .. " - OK"
+  return "Now Playing: " .. data.artist .. " - " .. data.track .. " - OK"
 end
 
+-- SCROBBLE
 if mympd_arguments.trigger == "scrobble" then
-  if mympd_state.current_song == nil then
+  if not mympd_state.current_song then
     return "Scrobble: Not playing"
   end
 
-  if mympd.tblvalue_in_list(mympd_env.var.scrobble_genre_blacklist, mympd_state.current_song.Genre) == true then
+  if mympd.tblvalue_in_list(mympd_env.var.scrobble_genre_blacklist, mympd_state.current_song.Genre) then
     return
   end
 
@@ -106,10 +119,10 @@ if mympd_arguments.trigger == "scrobble" then
     method      = "track.scrobble",
     api_key     = mympd_env.var.lastfm_api_key,
     timestamp   = tostring(mympd_state.start_time),
-    track       = mympd_state.current_song.Title,
-    artist      = mympd_state.current_song.Artist[1],
-    album       = mympd_state.current_song.Album,
-    albumArtist = mympd_state.current_song.AlbumArtist[1],
+    track       = mympd_state.current_song.Title or "",
+    artist      = firstTagValue(mympd_state.current_song.Artist),
+    album       = mympd_state.current_song.Album or "",
+    albumArtist = firstTagValue(mympd_state.current_song.AlbumArtist),
     sk          = mympd_env.var.lastfm_session_key,
   }
 
@@ -121,13 +134,15 @@ if mympd_arguments.trigger == "scrobble" then
 
   local ret = json.decode(body)
   local code = ret.scrobbles.scrobble.ignoredMessage.code
+
   if code ~= "0" then
-    return "Scrobble: " .. mympd_state.current_song.Artist[1] .. " - " .. mympd_state.current_song.Title .. " ignored, code " .. code
+    return "Scrobble: " .. data.artist .. " - " .. data.track .. " ignored, code " .. code
   end
 
-  return "Scrobble: " .. mympd_state.current_song.Artist[1] .. " - " .. mympd_state.current_song.Title .. " OK"
+  return "Scrobble: " .. data.artist .. " - " .. data.track .. " OK"
 end
 
+-- FEEDBACK
 if mympd_arguments.trigger == "feedback" then
   if mympd_arguments.type == "like" then
     if mympd_arguments.vote == "1" then
@@ -139,15 +154,15 @@ if mympd_arguments.trigger == "feedback" then
     end
   end
 
-  if mympd_state.current_song == nil then
+  if not mympd_state.current_song then
     return "Feedback: Not playing"
   end
 
   local data = {
     method      = "track.love",
     api_key     = mympd_env.var.lastfm_api_key,
-    track       = mympd_state.current_song.Title,
-    artist      = mympd_state.current_song.Artist[1],
+    track       = mympd_state.current_song.Title or "",
+    artist      = firstTagValue(mympd_state.current_song.Artist),
     sk          = mympd_env.var.lastfm_session_key,
   }
 
@@ -157,18 +172,20 @@ if mympd_arguments.trigger == "feedback" then
     return "Feedback: Error"
   end
 
-  return "Feedback: " .. mympd_state.current_song.Artist[1] .. " - " .. mympd_state.current_song.Title .. " OK"
+  return "Feedback: " .. data.artist .. " - " .. data.track .. " OK"
 end
 
+-- GET SESSION KEY DIALOG
 if mympd_arguments.trigger == "key" then
   local data = {
     { name = "Username", type = "text", value = "" },
-    { name = "Password", type = "password", value = ""},
-    { name = "trigger", type = "hidden", value = "fetchkey"}
+    { name = "Password", type = "password", value = "" },
+    { name = "trigger",  type = "hidden", value = "fetchkey" }
   }
-  return mympd.dialog("Get last.fm key", data, "lastfm")
+  return mympd.dialog("Get Last.fm key", data, "lastfm")
 end
 
+-- FETCH SESSION KEY
 if mympd_arguments.trigger == "fetchkey" then
   local data = {
     method   = "auth.getMobileSession",
@@ -180,7 +197,11 @@ if mympd_arguments.trigger == "fetchkey" then
   local body
   rc, body = sendData(data)
   local ret = json.decode(body)
-  mympd.api("MYMPD_API_SCRIPT_VAR_SET", { key = "lastfm_session_key", value = ret.session.key })
+
+  mympd.api("MYMPD_API_SCRIPT_VAR_SET", {
+    key = "lastfm_session_key",
+    value = ret.session.key
+  })
 
   return "Set session key for last.fm to " .. ret.session.key
 end

--- a/last.fm/lastfm.lua
+++ b/last.fm/lastfm.lua
@@ -203,7 +203,7 @@ if mympd_arguments.trigger == "fetchkey" then
     value = ret.session.key
   })
 
-  return "Set session key for last.fm to " .. ret.session.key
+  return "Set session key for Last.fm to " .. ret.session.key
 end
 
 return "lastfm: unknown function"


### PR DESCRIPTION
- add function `firstTagValue` - prevents crashes when AlbumArtist or other metadata fields are missing
- replace `pairs` with `ipairs` - ensures deterministic and validated Last.fm API signatures
- minor syntax improvements